### PR TITLE
add interactive cube GUI

### DIFF
--- a/code/axes3d.py
+++ b/code/axes3d.py
@@ -1,0 +1,181 @@
+import numpy as np
+import matplotlib.pyplot as plt
+from projection import Quaternion, project_points
+
+
+class PolyView3D(plt.Axes):
+    def __init__(self, view=(0, 0, 10), fig=None,
+                 rect=[0, 0, 1, 1], **kwargs):
+        if fig is None:
+            fig = plt.gcf()
+
+        self.view = np.asarray(view)
+        self.start_rot = Quaternion.from_v_theta((1, -1, 0), -np.pi / 6)
+
+        # Define movement for up/down arrows or up/down mouse movement
+        self._ax_UD = (1, 0, 0)
+        self._step_UD = 0.01
+
+        # Define movement for left/right arrows or left/right mouse movement
+        self._ax_LR = (0, -1, 0)
+        self._step_LR = 0.01
+
+        # Internal state variable
+        self._event_xy = None
+        self._current_rot = self.start_rot
+        self._npts = [1]
+        self._xyzs = [[0, 0, 0]]
+        self._polys = []
+
+        # initialize the axes.  We'll set some keywords by default
+        kwargs.update(dict(aspect='equal',
+                           xlim=(-2.5, 2.5), ylim=(-2.5, 2.5),
+                           frameon=False, xticks=[], yticks=[]))
+        super(PolyView3D, self).__init__(fig, rect, **kwargs)
+        self.xaxis.set_major_formatter(plt.NullFormatter())
+        self.yaxis.set_major_formatter(plt.NullFormatter())
+
+        # connect some GUI events
+        self.figure.canvas.mpl_connect('button_press_event',
+                                       self._mouse_press)
+        self.figure.canvas.mpl_connect('button_release_event',
+                                       self._mouse_release)
+        self.figure.canvas.mpl_connect('motion_notify_event',
+                                       self._mouse_motion)
+        self.figure.canvas.mpl_connect('key_press_event',
+                                       self._key_press)
+        self.figure.canvas.mpl_connect('key_release_event',
+                                       self._key_release)
+
+    def poly3D(self, xyz, update=True, **kwargs):
+        xyz = np.asarray(xyz)
+        self._npts.append(xyz.shape[0] + self._npts[-1])
+        self._xyzs = np.vstack([self._xyzs, xyz])
+
+        self._polys.append(plt.Polygon(xyz[:, :2], **kwargs))
+        self.add_patch(self._polys[-1])
+
+        if update:
+            self._update_projection()
+
+    def rotate(self, rot):
+        self._current_rot = self._current_rot * rot
+
+    def _update_projection(self):
+        proj = project_points(self._xyzs, self._current_rot, self.view)
+        for i in range(len(self._polys)):
+            p = proj[self._npts[i]:self._npts[i + 1]]
+            self._polys[i].set_xy(p[:, :2])
+            self._polys[i].set_zorder(-p[:-1, 2].mean())
+        self.figure.canvas.draw()
+
+    def _key_press(self, event):
+        """Handler for key press events"""
+        if event.key == 'shift':
+            self._ax_LR = (0, 0, 1)
+            self._shift_on = True
+
+        elif event.key == 'right':
+            self.rotate(Quaternion.from_v_theta(self._ax_LR,
+                                                self._step_LR))
+        elif event.key == 'left':
+            self.rotate(Quaternion.from_v_theta(self._ax_LR,
+                                                -self._step_LR))
+        elif event.key == 'up':
+            self.rotate(Quaternion.from_v_theta(self._ax_UD,
+                                                self._step_UD))
+        elif event.key == 'down':
+            self.rotate(Quaternion.from_v_theta(self._ax_UD,
+                                                -self._step_UD))
+        self._update_projection()
+
+    def _key_release(self, event):
+        """Handler for key release event"""
+        if event.key == 'shift':
+            self._ax_LR = (0, -1, 0)
+
+    def _mouse_press(self, event):
+        """Handler for mouse button press"""
+        if event.button == 1:
+            self._event_xy = (event.x, event.y)
+
+    def _mouse_release(self, event):
+        """Handler for mouse button release"""
+        if event.button == 1:
+            self._event_xy = None
+
+    def _mouse_motion(self, event):
+        """Handler for mouse motion"""
+        if self._event_xy is not None:
+            dx = event.x - self._event_xy[0]
+            dy = event.y - self._event_xy[1]
+            self._event_xy = (event.x, event.y)
+            rot1 = Quaternion.from_v_theta(self._ax_UD,
+                                           self._step_UD * dy)
+            rot2 = Quaternion.from_v_theta(self._ax_LR,
+                                           self._step_LR * dx)
+
+            self.rotate(rot1 * rot2)
+            self._update_projection()
+
+
+def cube_axes(N=1, **kwargs):
+    stickerwidth = 0.9
+    small = 0.5 * (1. - stickerwidth)
+    d1 = 1 - small
+    d2 = 1 - 2 * small
+    d3 = 1.01
+    base_sticker = np.array([[d1, d2, d3],
+                             [d2, d1, d3],
+                             [-d2, d1, d3],
+                             [-d1, d2, d3],
+                             [-d1, -d2, d3],
+                             [-d2, -d1, d3],
+                             [d2, -d1, d3],
+                             [d1, -d2, d3],
+                             [d1, d2, d3]], dtype=float)
+
+    base_face = np.array([[1, 1, 1],
+                          [1, -1, 1],
+                          [-1, -1, 1],
+                          [-1, 1, 1],
+                          [1, 1, 1]], dtype=float)
+
+    x, y, z = np.eye(3)
+    rots = [Quaternion.from_v_theta(x, theta)
+            for theta in (np.pi / 2, -np.pi / 2)]
+    rots += [Quaternion.from_v_theta(y, theta)
+            for theta in (np.pi / 2, -np.pi / 2, np.pi, 2 * np.pi)]
+
+    cubie_width = 2. / N
+    translations = np.array([[-1 + (i + 0.5) * cubie_width,
+                              -1 + (j + 0.5) * cubie_width, 0]
+                             for i in range(N) for j in range(N)])
+
+    colors = ['blue', 'green', 'white', 'yellow', 'orange', 'red']
+    
+    factor = np.array([1. / N, 1. / N, 1])
+
+    ax = PolyView3D(**kwargs)
+    for t in translations:
+        base_face_trans = factor * base_face + t
+        base_sticker_trans = factor * base_sticker + t
+        for r, c in zip(rots, colors):
+            face = r.rotate(base_face_trans)
+            ax.poly3D(face, facecolor='k', update=False)
+            sticker = r.rotate(base_sticker_trans)
+            ax.poly3D(sticker, facecolor=c, update=False)
+
+    ax._update_projection()
+
+    ax.figure.text(0.05, 0.05, ("Drag Mouse or use arrow keys to change "
+                                "perspective.\n"
+                                "hold shift to rotate around z-axis"),
+                   ha='left', va='bottom')
+    return ax
+        
+
+if __name__ == '__main__':
+    fig = plt.figure(figsize=(5, 5))
+    fig.add_axes(cube_axes(N=3, fig=fig))
+    plt.show()

--- a/code/cube_interactive.py
+++ b/code/cube_interactive.py
@@ -244,7 +244,7 @@ class CubeAxes(Axes):
             [self.add_patch(self._cube_poly[i]) for i in range(6)]
 
         faces = self.project_points(self.faces, rot, zloc)
-        zorder = np.argsort(np.argsort(faces[:, :, 2].sum(1)))
+        zorder = np.argsort(np.argsort(faces[:, :4, 2].sum(1)))
 
         [self._cube_poly[i].set_zorder(10 * zorder[i]) for i in range(6)]
         [self._cube_poly[i].set_xy(faces[i, :, :2]) for i in range(6)]

--- a/code/cube_interactive.py
+++ b/code/cube_interactive.py
@@ -1,0 +1,238 @@
+import numpy as np
+from matplotlib.axes import Axes
+from matplotlib.collections import PolyCollection
+import matplotlib.pyplot as plt
+
+#------------------------------------------------------------
+# Some simple quaternion operations
+
+class Quaternion:
+    """Quaternion Rotation:
+
+    Class to aid in representing 3D rotations via quaternions.
+    """
+    @classmethod
+    def from_v_theta(cls, v, theta):
+        theta = np.asarray(theta)
+        v = np.asarray(v)
+        s = np.sin(0.5 * theta)
+        c = np.cos(0.5 * theta)
+
+        v = v * s / np.sqrt(np.sum(v * v, -1))
+        x_shape = v.shape[:-1] + (4,)
+
+        x = np.ones(x_shape).reshape(-1, 4)
+        x[:, 0] = c.ravel()
+        x[:, 1:] = v.reshape(-1, 3)
+        x = x.reshape(x_shape)
+
+        return cls(x)
+
+    def __init__(self, x):
+        self.x = np.asarray(x, dtype=float)
+
+    def __add__(self, other):
+        return self.__class__(self.x + other.x)
+
+    def __repr__(self):
+        return self.x.__repr__()
+
+    def __mul__(self, other):
+        sxr = self.x.reshape(self.x.shape[:-1] + (4, 1))
+        oxr = other.x.reshape(other.x.shape[:-1] + (1, 4))
+
+        prod = sxr * oxr
+        return_shape = prod.shape[:-1]
+        prod = prod.reshape((-1, 4, 4)).transpose((1, 2, 0))
+
+        ret = np.array([(prod[0, 0] - prod[1, 1]
+                         - prod[2, 2] - prod[3, 3]),
+                        (prod[0, 1] + prod[1, 0]
+                         + prod[2, 3] - prod[3, 2]),
+                        (prod[0, 2] - prod[1, 3]
+                         + prod[2, 0] + prod[3, 1]),
+                        (prod[0, 3] + prod[1, 2]
+                         - prod[2, 1] + prod[3, 0])],
+                       dtype=np.float,
+                       order='F').T
+        return self.__class__(ret.reshape(return_shape))
+
+    def as_v_theta(self):
+        """Return the v, theta equivalent of the (normalized) quaternion"""
+        x = self.x.reshape((-1, 4)).T
+
+        # compute theta
+        norm = np.sqrt((x ** 2).sum(0))
+        theta = 2 * np.arccos(x[0] / norm)
+
+        # compute the unit vector
+        v = np.array(x[1:], order='F', copy=True)
+        v /= np.sqrt(np.sum(v ** 2, 0))
+
+        # reshape the results
+        v = v.T.reshape(self.x.shape[:-1] + (3,))
+        theta = theta.reshape(self.x.shape[:-1])
+
+        return v, theta
+
+    def as_rotation_matrix(self):
+        """Return the rotation matrix of the (normalized) quaternion"""
+        v, theta = self.as_v_theta()
+
+        shape = theta.shape
+        theta = theta.reshape(-1)
+        v = v.reshape(-1, 3).T
+        c = np.cos(theta)
+        s = np.sin(theta)
+
+        mat = np.array([[v[0] * v[0] * (1. - c) + c,
+                         v[0] * v[1] * (1. - c) - v[2] * s,
+                         v[0] * v[2] * (1. - c) + v[1] * s],
+                        [v[1] * v[0] * (1. - c) + v[2] * s,
+                         v[1] * v[1] * (1. - c) + c,
+                         v[1] * v[2] * (1. - c) - v[0] * s],
+                        [v[2] * v[0] * (1. - c) - v[1] * s,
+                         v[2] * v[1] * (1. - c) + v[0] * s,
+                         v[2] * v[2] * (1. - c) + c]],
+                       order='F')
+        return mat.T.reshape(shape + (3, 3))
+        
+
+class CubeAxes(Axes):
+    """Axes to show 3D cube
+
+    The cube orientation is represented by a quaternion.
+    The cube has side-length 2, and the observer is a distance R away
+    along the z-axis.
+    """
+    face = np.array([[1, 1], [1, -1], [-1, -1],
+                     [-1, 1], [1, 1], [0, 0]])
+    faces =  np.array([np.hstack([face[:, :i],
+                                  np.ones((6, 1)),
+                                  face[:, i:]]) for i in range(3)] +
+                      [np.hstack([face[:, :i],
+                                  -np.ones((6, 1)),
+                                  face[:, i:]]) for i in range(3)])
+    stickercolors = ["#ffffff", "#00008f", "#ff6f00",
+                     "#ffcf00", "#009f0f", "#cf0000"]
+
+    def __init__(self, *args, **kwargs):
+        self.start_rot = Quaternion.from_v_theta((1, -1, 0), np.pi / 6)
+        self.current_rot = self.start_rot
+
+        self.start_zloc = 10.
+        self.current_zloc = 10.
+
+        self._active = False
+        self._xy = None
+        self._cube_poly = None
+
+        kwargs.update(dict(aspect='equal', xlim=(-1.5, 1.5), ylim=(-1.5, 1.5),
+                           frameon=False, xticks=[], yticks=[]))
+        super(CubeAxes, self).__init__(*args, **kwargs)
+
+        self.figure.canvas.mpl_connect('button_press_event',
+                                       self._activate_rotation)
+        self.figure.canvas.mpl_connect('button_release_event',
+                                       self._deactivate_rotation)
+        self.figure.canvas.mpl_connect('motion_notify_event',
+                                       self._on_motion)
+        self.figure.canvas.mpl_connect('key_press_event',
+                                       self._key_press)
+
+    @staticmethod
+    def project_points(pts, rot, zloc):
+        """Project points to 2D given a rotation and a view
+
+        pts is an ndarray, last dimension 3
+        rot is a Quaternion object, containing a single quaternion
+        zloc is a distance along the z-axis from which the cube is being viewed
+        """
+        R = rot.as_rotation_matrix()
+        Rpts = np.dot(pts, R.T)
+
+        xdir = np.array([1., 0, 0])
+        ydir = np.array([0, 1., 0])
+        zdir = np.array([0, 0, 1.])
+
+        view = zloc * zdir
+        v2 = zloc ** 2
+
+        result = []
+        for p in Rpts.reshape((-1, 3)):
+            dpoint = p - view
+            dproj = 0.5 * dpoint * v2 / np.dot(dpoint, -1. * view)
+            result += [np.array([np.dot(xdir, dproj),
+                                 np.dot(ydir, dproj),
+                                 np.dot(zdir, dpoint / np.sqrt(v2))])]
+        return np.asarray(result).reshape(pts.shape)
+
+    def draw_cube(self, rot=None, zloc=None):
+        if rot is None:
+            rot = self.current_rot
+        if zloc is None:
+            zloc = self.current_zloc
+
+        self.current_rot = rot
+        self.current_zloc = zloc
+
+        if self._cube_poly is None:
+            self._cube_poly = [plt.Polygon(self.faces[i, :5, :2],
+                                           facecolor=self.stickercolors[i])
+                               for i in range(6)]
+            [self.add_patch(self._cube_poly[i]) for i in range(6)]
+
+        faces = self.project_points(self.faces, rot, zloc)
+        zorder = np.argsort(np.argsort(faces[:, 5, 2]))
+
+        [self._cube_poly[i].set_zorder(10 * zorder[i]) for i in range(6)]
+        [self._cube_poly[i].set_xy(faces[i, :5, :2]) for i in range(6)]
+
+        self.figure.canvas.draw()
+
+    def _key_press(self, event):
+        if event.key == 'right':
+            self.current_rot = (self.current_rot
+                                * Quaternion.from_v_theta((0, 1, 0), -0.05))
+        elif event.key == 'left':
+            self.current_rot = (self.current_rot
+                                * Quaternion.from_v_theta((0, 1, 0), 0.05))
+        elif event.key == 'up':
+            self.current_rot = (self.current_rot
+                                * Quaternion.from_v_theta((1, 0, 0), 0.05))
+        elif event.key == 'down':
+            self.current_rot = (self.current_rot
+                                * Quaternion.from_v_theta((1, 0, 0), -0.05))
+
+        self.draw_cube()
+
+    def _activate_rotation(self, event):
+        if event.button == 1:
+            self._active = True
+            self._xy = (event.x, event.y)
+
+    def _deactivate_rotation(self, event):
+        if event.button == 1:
+            self._active = False
+            self._xy = None
+
+    def _on_motion(self, event):
+        if self._active:
+            dx = event.x - self._xy[0]
+            dy = event.y - self._xy[1]
+            self._xy = (event.x, event.y)
+            theta = -0.005 * dx
+            phi = 0.005 * dy
+
+            self.current_rot = (self.current_rot *
+                                Quaternion.from_v_theta((1, 0, 0), phi) *
+                                Quaternion.from_v_theta((0, 1, 0), theta))
+
+            self.draw_cube()
+            
+
+fig = plt.figure()
+ax = CubeAxes(fig, [0, 0, 1, 1])
+fig.add_axes(ax)
+ax.draw_cube()
+plt.show()

--- a/code/projection.py
+++ b/code/projection.py
@@ -1,0 +1,162 @@
+import numpy as np
+
+class Quaternion:
+    """Quaternion Rotation:
+
+    Class to aid in representing 3D rotations via quaternions.
+    """
+    @classmethod
+    def from_v_theta(cls, v, theta):
+        """
+        Construct quaternions from unit vectors v and rotation angles theta
+
+        Parameters
+        ----------
+        v : array_like
+            array of vectors, last dimension 3. Vectors will be normalized.
+        theta : array_like
+            array of rotation angles in radians, shape = v.shape[:-1].
+
+        Returns
+        -------
+        q : quaternion object
+            quaternion representing the rotations
+        """
+        theta = np.asarray(theta)
+        v = np.asarray(v)
+        s = np.sin(0.5 * theta)
+        c = np.cos(0.5 * theta)
+
+        v = v * s / np.sqrt(np.sum(v * v, -1))
+        x_shape = v.shape[:-1] + (4,)
+
+        x = np.ones(x_shape).reshape(-1, 4)
+        x[:, 0] = c.ravel()
+        x[:, 1:] = v.reshape(-1, 3)
+        x = x.reshape(x_shape)
+
+        return cls(x)
+
+    def __init__(self, x):
+        self.x = np.asarray(x, dtype=float)
+
+    def __repr__(self):
+        return "Quaternion:\n" + self.x.__repr__()
+
+    def __mul__(self, other):
+        # multiplication of two quaternions.
+        # we don't implement multiplication by a scalar
+        sxr = self.x.reshape(self.x.shape[:-1] + (4, 1))
+        oxr = other.x.reshape(other.x.shape[:-1] + (1, 4))
+
+        prod = sxr * oxr
+        return_shape = prod.shape[:-1]
+        prod = prod.reshape((-1, 4, 4)).transpose((1, 2, 0))
+
+        ret = np.array([(prod[0, 0] - prod[1, 1]
+                         - prod[2, 2] - prod[3, 3]),
+                        (prod[0, 1] + prod[1, 0]
+                         + prod[2, 3] - prod[3, 2]),
+                        (prod[0, 2] - prod[1, 3]
+                         + prod[2, 0] + prod[3, 1]),
+                        (prod[0, 3] + prod[1, 2]
+                         - prod[2, 1] + prod[3, 0])],
+                       dtype=np.float,
+                       order='F').T
+        return self.__class__(ret.reshape(return_shape))
+
+    def as_v_theta(self):
+        """Return the v, theta equivalent of the (normalized) quaternion"""
+        x = self.x.reshape((-1, 4)).T
+
+        # compute theta
+        norm = np.sqrt((x ** 2).sum(0))
+        theta = 2 * np.arccos(x[0] / norm)
+
+        # compute the unit vector
+        v = np.array(x[1:], order='F', copy=True)
+        v /= np.sqrt(np.sum(v ** 2, 0))
+
+        # reshape the results
+        v = v.T.reshape(self.x.shape[:-1] + (3,))
+        theta = theta.reshape(self.x.shape[:-1])
+
+        return v, theta
+
+    def as_rotation_matrix(self):
+        """Return the rotation matrix of the (normalized) quaternion"""
+        v, theta = self.as_v_theta()
+
+        shape = theta.shape
+        theta = theta.reshape(-1)
+        v = v.reshape(-1, 3).T
+        c = np.cos(theta)
+        s = np.sin(theta)
+
+        mat = np.array([[v[0] * v[0] * (1. - c) + c,
+                         v[0] * v[1] * (1. - c) - v[2] * s,
+                         v[0] * v[2] * (1. - c) + v[1] * s],
+                        [v[1] * v[0] * (1. - c) + v[2] * s,
+                         v[1] * v[1] * (1. - c) + c,
+                         v[1] * v[2] * (1. - c) - v[0] * s],
+                        [v[2] * v[0] * (1. - c) - v[1] * s,
+                         v[2] * v[1] * (1. - c) + v[0] * s,
+                         v[2] * v[2] * (1. - c) + c]],
+                       order='F').T
+        return mat.reshape(shape + (3, 3))
+
+    def rotate(self, points):
+        M = self.as_rotation_matrix()
+        return np.dot(points, M.T)
+
+
+def project_points(points, q, view, vertical=[0, 1, 0]):
+    """Project points using a quaternion q and a view v
+
+    Parameters
+    ----------
+    points : array_like
+        array of last-dimension 3
+    q : Quaternion
+        quaternion representation of the rotation
+    view : array_like
+        length-3 vector giving the point of view
+    vertical : array_like
+        direction of y-axis for view.  An error will be raised if it
+        is parallel to the view.
+
+    Returns
+    -------
+    proj: array_like
+        array of projected points: same shape as points.
+    """
+    points = np.asarray(points)
+    view = np.asarray(view)
+
+    xdir = np.cross(vertical, view).astype(float)
+
+    if np.all(xdir == 0):
+        raise ValueError("vertical is parallel to v")
+
+    xdir /= np.sqrt(np.dot(xdir, xdir))
+
+    # get the unit vector corresponing to vertical
+    ydir = np.cross(view, xdir)
+    ydir /= np.sqrt(np.dot(ydir, ydir))
+
+    # normalize the viewer location: this is the z-axis
+    v2 = np.dot(view, view)
+    zdir = view / np.sqrt(v2)
+
+    # rotate the points
+    R = q.as_rotation_matrix()
+    Rpts = np.dot(points, R.T)
+
+    # project the points onto the view
+    dpoint = Rpts - view
+    dpoint_view = np.dot(dpoint, view).reshape(dpoint.shape[:-1] + (1,))
+    dproj = -dpoint * v2 / dpoint_view
+
+    return np.vstack([np.dot(dproj, xdir),
+                      np.dot(dproj, ydir),
+                      -np.dot(dpoint, zdir)]).T


### PR DESCRIPTION
This adds a small script which allows rotating a cube interactively in matplotlib.

Run `python axes3d.py` to see the cube: change N in the script to visualize smaller or larger cubes.

Next step: incorporate this cube viewer with the representation in `cube.py`.  Then (some day)  a full matplotlib cube API for turning the faces.  I have some ideas for how to do it, but it could take some thinking...
